### PR TITLE
remove NDA warnings

### DIFF
--- a/include/fl2000_ioctl.h
+++ b/include/fl2000_ioctl.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: IOCTL definitions for FL2000 Linux kernel driver.
 //
 // NOTE: THIS FILE MAY BE SENT OUTSIDE OF FRESCO LOGIC.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,9 +2,6 @@
 #
 # (c)Copyright 2017, Fresco Logic, Incorporated.
 #
-# The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-# by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-#
 # Purpose:
 #
 # NOTE: DO NOT SEND THIS FILE OUTSIDE OF FRESCO LOGIC.

--- a/src/fl2000_big_table.c
+++ b/src/fl2000_big_table.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: TODO: PLEASE RENAME THIS FILE TO SOMETHING USEFUL
 //
 

--- a/src/fl2000_big_table.h
+++ b/src/fl2000_big_table.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_bulk.c
+++ b/src/fl2000_bulk.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Bulk Pipe Support
 //
 

--- a/src/fl2000_bulk.h
+++ b/src/fl2000_bulk.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion File.
 //
 

--- a/src/fl2000_compression.c
+++ b/src/fl2000_compression.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Compression.
 //
 

--- a/src/fl2000_compression.h
+++ b/src/fl2000_compression.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion file.
 //
 

--- a/src/fl2000_ctx.h
+++ b/src/fl2000_ctx.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_def.h
+++ b/src/fl2000_def.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_desc.c
+++ b/src/fl2000_desc.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_desc.h
+++ b/src/fl2000_desc.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_dev.c
+++ b/src/fl2000_dev.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_dev.h
+++ b/src/fl2000_dev.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_dongle.c
+++ b/src/fl2000_dongle.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2009-2013, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_dongle.h
+++ b/src/fl2000_dongle.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2009-2013, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_fops.c
+++ b/src/fl2000_fops.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_hdmi.c
+++ b/src/fl2000_hdmi.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2009-2013, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_hdmi.h
+++ b/src/fl2000_hdmi.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion file.
 //
 

--- a/src/fl2000_i2c.c
+++ b/src/fl2000_i2c.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 #include "fl2000_include.h"

--- a/src/fl2000_i2c.h
+++ b/src/fl2000_i2c.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2009-2013, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_include.h
+++ b/src/fl2000_include.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_interrupt.c
+++ b/src/fl2000_interrupt.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2010-2013, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Interrupt Pipe Support
 //
 

--- a/src/fl2000_interrupt.h
+++ b/src/fl2000_interrupt.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion file.
 //
 

--- a/src/fl2000_ioctl.c
+++ b/src/fl2000_ioctl.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Utility Primitives
 //
 

--- a/src/fl2000_ioctl.h
+++ b/src/fl2000_ioctl.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: IOCTL definitions for FL2000 Linux kernel driver.
 //
 // NOTE: THIS FILE MAY BE SENT OUTSIDE OF FRESCO LOGIC.

--- a/src/fl2000_linux.h
+++ b/src/fl2000_linux.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_log.h
+++ b/src/fl2000_log.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion File
 //
 

--- a/src/fl2000_module.c
+++ b/src/fl2000_module.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_module.h
+++ b/src/fl2000_module.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_monitor.c
+++ b/src/fl2000_monitor.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_monitor.h
+++ b/src/fl2000_monitor.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_register.c
+++ b/src/fl2000_register.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: USBVGA Device Register Primitives
 //
 

--- a/src/fl2000_register.h
+++ b/src/fl2000_register.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 20017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose:
 //
 

--- a/src/fl2000_render.c
+++ b/src/fl2000_render.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Render Device Support
 //
 

--- a/src/fl2000_render.h
+++ b/src/fl2000_render.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion file.
 //
 

--- a/src/fl2000_surface.c
+++ b/src/fl2000_surface.c
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Utility Primitives
 //
 

--- a/src/fl2000_surface.h
+++ b/src/fl2000_surface.h
@@ -2,9 +2,6 @@
 //
 // (c)Copyright 2017, Fresco Logic, Incorporated.
 //
-// The contents of this file are property of Fresco Logic, Incorporated and are strictly protected
-// by Non Disclosure Agreements. Distribution in any form to unauthorized parties is strictly prohibited.
-//
 // Purpose: Companion File.
 //
 #ifndef _FL2000_SURFACE_H_


### PR DESCRIPTION
The driver has been released under the GPL 2.0 on github, remove the scary NDA warnings that probably unintentionally have been left in the code.