### PR TITLE
Only reuse intfdata from a different ifc if the driver is the same

### DIFF
--- a/src/fl2000_module.c
+++ b/src/fl2000_module.c
@@ -85,7 +85,8 @@ fl2000_device_probe(
 	config = usb_dev->actconfig;
 	for (index = 0; index < USB_MAXINTERFACES; index ++) {
 		other_ifc = config->interface[index];
-		if (other_ifc && other_ifc != ifc) {
+		if (other_ifc && other_ifc != ifc &&
+		    to_usb_driver(other_ifc->dev.driver) == &fl2000_driver) {
 			dev_ctx = usb_get_intfdata(other_ifc);
 			if (dev_ctx)
 				break;


### PR DESCRIPTION
Without this check the driver would stomp all over the intfdata owned
by the mass storage driver which binds to the last interface which is
a mass storage device containing the (Windows) drivers.